### PR TITLE
Add username to description

### DIFF
--- a/Website/www/omni/welcome/instructions.php
+++ b/Website/www/omni/welcome/instructions.php
@@ -73,7 +73,7 @@ BeaconTemplate::FinishStyles();
 	<div class="signin_text">
 		<h4>Click the &quot;Sign In&quot; link</h4>
 		<p>If you see &quot;Enable Cloud &amp; Community&quot; instead, click that one.</p>
-		<p>If you see your email address or username instead, you're already signed in! Relaunch Beacon to activate Omni. Or you can click &quot;Sign Out&quot; if you see a different email address.</p>
+		<p>If you see your username instead, you're already signed in! Relaunch Beacon to activate Omni. Or you can click &quot;Sign Out&quot; if you see a different email address.</p>
 	</div>
 	<div class="push">&nbsp;</div>
 </div>

--- a/Website/www/omni/welcome/instructions.php
+++ b/Website/www/omni/welcome/instructions.php
@@ -73,7 +73,7 @@ BeaconTemplate::FinishStyles();
 	<div class="signin_text">
 		<h4>Click the &quot;Sign In&quot; link</h4>
 		<p>If you see &quot;Enable Cloud &amp; Community&quot; instead, click that one.</p>
-		<p>If you see your email address instead, you're already signed in! Relaunch Beacon to activate Omni. Or you can click &quot;Sign Out&quot; if you see a different email address.</p>
+		<p>If you see your email address or username instead, you're already signed in! Relaunch Beacon to activate Omni. Or you can click &quot;Sign Out&quot; if you see a different email address.</p>
 	</div>
 	<div class="push">&nbsp;</div>
 </div>


### PR DESCRIPTION
The menu shows the username, not the email address when signed in in Beacon app.